### PR TITLE
Fix: Set non-root USERID in otelcontribcol Dockerfile

### DIFF
--- a/cmd/otelcontribcol/Dockerfile
+++ b/cmd/otelcontribcol/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest as prep
 RUN apk --update add ca-certificates
 
-ARG USER_UID=10001
+ARG USER_UID=65532:65532
 
 RUN mkdir -p /tmp
 


### PR DESCRIPTION
**Description:** Setting the USERID in otelcontribcol Dockerfile as non-root to facilitate running otel collector containers with `runAsNonRoot: true`
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** NA

**Testing:** Done locally

**Documentation:** NA