### PR TITLE
Fix: Update otelcontribcol Dockerfile USER for alpine image

### DIFF
--- a/cmd/otelcontribcol/Dockerfile
+++ b/cmd/otelcontribcol/Dockerfile
@@ -1,11 +1,14 @@
+ARG USER_UID=65532:65532
+
 FROM alpine:latest as prep
+ARG USER_UID
 RUN apk --update add ca-certificates
 
-ARG USER_UID=65532:65532
 RUN mkdir -p /tmp
 USER ${USER_UID}
 
 FROM scratch
+ARG USER_UID
 
 COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY otelcontribcol /

--- a/cmd/otelcontribcol/Dockerfile
+++ b/cmd/otelcontribcol/Dockerfile
@@ -1,16 +1,14 @@
 FROM alpine:latest as prep
 RUN apk --update add ca-certificates
 
-ARG USER_UID=65532:65532
-
 RUN mkdir -p /tmp
+USER 65532:65532
 
 FROM scratch
-
-USER ${USER_UID}
 
 COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY otelcontribcol /
 EXPOSE 4317 55680 55679
+USER 65532:65532
 ENTRYPOINT ["/otelcontribcol"]
 CMD ["--config", "/etc/otel/config.yaml"]

--- a/cmd/otelcontribcol/Dockerfile
+++ b/cmd/otelcontribcol/Dockerfile
@@ -1,14 +1,15 @@
 FROM alpine:latest as prep
 RUN apk --update add ca-certificates
 
+ARG USER_UID=65532:65532
 RUN mkdir -p /tmp
-USER 65532:65532
+USER ${USER_UID}
 
 FROM scratch
 
 COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY otelcontribcol /
 EXPOSE 4317 55680 55679
-USER 65532:65532
+USER ${USER_UID}
 ENTRYPOINT ["/otelcontribcol"]
 CMD ["--config", "/etc/otel/config.yaml"]


### PR DESCRIPTION
**Description:** Adding non-root user id for alpine image used in otelcontribcol Dockerfile

**Link to tracking Issue:** NA

**Testing:** Local kind cluster

**Documentation:** NA